### PR TITLE
Chore/init testing

### DIFF
--- a/simmons.go
+++ b/simmons.go
@@ -32,7 +32,7 @@ var client Storer
 //
 // Returns an ORM configuration option func.
 func Init(conn string) error {
-	DB, err := gorm.Open(conn)
+	DB, err := gorm.Open("mysql", conn)
 	if err != nil {
 		return fmt.Errorf("error intializing simmons Database, Err: %v", err)
 	}
@@ -42,6 +42,15 @@ func Init(conn string) error {
 	}
 
 	return nil
+}
+
+// Close closes the database connection for the underlying gorm database.
+//
+// Returns nothing.
+func Close() {
+	if c, ok := client.(*Client); ok {
+		c.DB.Close()
+	}
 }
 
 // Init test initializes simmons with a custom storer, usually intended to be

--- a/simmons.go
+++ b/simmons.go
@@ -44,6 +44,16 @@ func Init(conn string) error {
 	return nil
 }
 
+// Init test initializes simmons with a custom storer, usually intended to be
+// initialized with a simmons.FakeClient with customized funcs for mocking.
+//
+// - storer: A simmons.Storer interface implementer.
+//
+// Returns nothing.
+func InitTest(storer Storer) {
+	client = storer
+}
+
 // Create persists models for first time.
 //
 // - model: The model to persists.


### PR DESCRIPTION
This PR adds a `InitTest` method for simmons in order to get it initialized with a FakeClient for testing / mock purposes.

> Also it fixes the `Init` method as it was not working previously and adds a `Close` method to close the underlying gorm ORM database connection.